### PR TITLE
Fixed redundant display of user details in the UserDetails view

### DIFF
--- a/src/View/UserDetails.java
+++ b/src/View/UserDetails.java
@@ -37,6 +37,11 @@ public class UserDetails extends JPanel {
         DefaultTableModel defaultTableModel = (DefaultTableModel) userTable.getModel();
         defaultTableModel.setColumnIdentifiers(userTableColumn);
         int i = 0;
+        if (defaultTableModel.getRowCount() > 0) {
+            for (int j = defaultTableModel.getRowCount() - 1; j > -1; j--) {
+                defaultTableModel.removeRow(j);
+            }
+        }
         while(i < objects.length) {
             String row = objects[i].toString().trim();
             String[] rows = row.split(",");


### PR DESCRIPTION
In the UserDetails.java View file, the defaultTableModel would not clear out due to which the user details got duplicated onto the view. I added a simple check in order to clear out the rows of the table while calling the getUsers() function (in UserDetails.java) so that the objects of the database get added to the table only once, hence avoiding redundant display at the view. 